### PR TITLE
To ProblemDetails depth support

### DIFF
--- a/Genesis.MinimalApis/ExceptionExtensions.cs
+++ b/Genesis.MinimalApis/ExceptionExtensions.cs
@@ -17,8 +17,7 @@ public static partial class ExceptionExtensions {
 
         for (ushort i = 0;
             i < maxMessageDepth && exception.InnerException is not null;
-            i++, exception = exception.InnerException
-        );
+            i++, exception = exception.InnerException);
 
         return exception switch {
             ArgumentException aex =>

--- a/Genesis.MinimalApis/ExceptionExtensions.cs
+++ b/Genesis.MinimalApis/ExceptionExtensions.cs
@@ -1,6 +1,18 @@
 ﻿namespace Genesis;
 
 public static partial class ExceptionExtensions {
+
+    /// <summary>
+    /// Convert an exception to a <see cref="ProblemDetails"/> object
+    /// <code>
+    /// var e = new Exception("Message 1", new("Message 0"));
+    /// e.ToProblemDetails(1).Detail; // result is "Message 0"
+    /// e.ToProblemDetails().Detail; // result is "Message 1"
+    /// </code>
+    /// </summary>
+    /// <param name="exception">The exception to convert</param>
+    /// <param name="maxMessageDepth">Optional maximum inner exception depth to use as the <see cref="ProblemDetails.Detail"/> property</param>
+    /// <returns>A <see cref="ProblemDetails"/> with a <see cref="ProblemDetails.Detail"/> being <see cref="Exception.InnerException"/> message at the specified depth</returns>
     public static ProblemDetails ToProblemDetails(this Exception exception, ushort maxMessageDepth = 1) {
 
         for (ushort i = 0;

--- a/Genesis.MinimalApis/ExceptionExtensions.cs
+++ b/Genesis.MinimalApis/ExceptionExtensions.cs
@@ -1,8 +1,14 @@
 ﻿namespace Genesis;
 
 public static partial class ExceptionExtensions {
-    public static ProblemDetails ToProblemDetails(this Exception exception) =>
-        exception switch {
+    public static ProblemDetails ToProblemDetails(this Exception exception, ushort maxMessageDepth = 1) {
+
+        for (ushort i = 0;
+            i < maxMessageDepth && exception.InnerException is not null;
+            i++, exception = exception.InnerException
+        );
+
+        return exception switch {
             ArgumentException aex =>
                 new ValidationProblemDetails(
                     new Dictionary<string, string[]> {
@@ -33,4 +39,5 @@ public static partial class ExceptionExtensions {
                     Status = StatusCodes.Status500InternalServerError
                 }
         };
+    }
 }

--- a/Genesis.MinimalApis/Genesis.MinimalApis.csproj
+++ b/Genesis.MinimalApis/Genesis.MinimalApis.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>6.3.0</Version>
+    <Version>6.3.1</Version>
     <Authors>Mark Pro, StratusCube Contributors</Authors>
     <Company>StratusCube</Company>
     <Description>Allows for the the registration of minimal endpoints from either manual deffinition or by the use of AspNet.MVC route attributes.</Description>

--- a/Tests/MinimalEndpoints.Tests/ExceptionExtensionTests.cs
+++ b/Tests/MinimalEndpoints.Tests/ExceptionExtensionTests.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
+using System.Linq;
 
 namespace MinimalEndpoints.Tests;
 
@@ -41,5 +42,28 @@ public class ExceptionExtensionTests {
 #endif
         })((string s) => details.Title.Should().Be(s));
     }
+
+    [TestMethod]
+    [DynamicData(nameof(Depths), DynamicDataSourceType.Property)]
+    public void DepthTest(ushort depth) {
+
+        Exception exceptionGenerator(ushort depth) {
+            var e = new Exception("Exception message 0");
+            for (ushort i = 0; i < depth; i++)
+                e = new($"Exception message {i + 1}", e);
+
+            return e;
+        }
+
+        var count = (ushort)Depths.Length;
+
+        var pd = exceptionGenerator((ushort)count).ToProblemDetails(depth);
+        pd.Detail.Should().Be($"Exception message {count - depth}");
+    }
+
+    static object[][] Depths =>
+        Enumerable.Range(0, 5)
+        .Select(i => new object[] { (ushort) i })
+        .ToArray();
 }
 


### PR DESCRIPTION
Added depth support for inner exceptions such that the depth can be specified.

If specified the `ProblemDetails.Detail` will be the message of the inner exception at the specified depth.
the default depth is set to 0